### PR TITLE
Changes in parameters file, READme, and output folders for v.2.1.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,10 @@
 
 # PEMA: 
 ### a flexible Pipeline for Environmental DNA Metabarcoding Analysis of the 16S/18S rRNA, ITS and COI marker genes 
-*PEMA is reposited in* [*Docker Hub*](https://hub.docker.com/r/hariszaf/pema) *as well as in* [*Singularity Hub*](https://singularity-hub.org/collections/2295)
-
+*PEMA is reposited in* [*Docker Hub*](https://hub.docker.com/r/hariszaf/pema) 
 #### PEMA website along with *how to* documentation can be found [**here**](https://hariszaf.github.io/pema_documentation/).
 
 #### For any troubles you may have when running PEMA or for any potential improvevments you would like to suggest, please share on the [PEMA Gitter community](https://gitter.im/pema-helpdesk/community).
-
 
 [![Gitter](https://badges.gitter.im/pema-helpdesk/community.svg)](https://gitter.im/pema-helpdesk/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
@@ -80,10 +78,7 @@ For the latter, a reference tree of 1000 taxa was created using SILVA_132_SSURef
 PEMA has been implemented in [BigDataScript](https://pcingola.github.io/BigDataScript/) programming language. BDS’s ad hoc task parallelism and task synchronization, supports heavyweight computation. Thus, PEMA inherits such features and it also supports roll-back checkpoints and on-demand partial pipeline execution. In addition, PEMA takes advantage of all the computational power available on a specific machine; for example, if PEMA is executed on a personal laptop with 4 cores, it is going to use all four of them. 
 
 Finally, container-based technologies such as Docker and Singularity, make PEMA easy accessible for all operating systems.
-As you can see in the [PEMA_tutorial.pdf](https://github.com/hariszaf/pema/blob/master/help_files/GitHub%20tutorial.pdf), once you have either Docker or Singularity on your computational environment (see below which suits your case better), running PEMA is cakewalk. You can also find the [**PEMA tutorial**](https://docs.google.com/presentation/d/1lVH23DPa2NDNBhVvOTRoip8mraw8zfw8VQwbK4vkB1U/edit?usp=sharing) as a Google Slides file.
-
-
-
+As you can see in the [PEMA documentation](https://hariszaf.github.io/pema_documentation/2.running_general/), once you have either Docker or Singularity on your computational environment (see below which suits your case better), running PEMA is cakewalk. You can also find the [**PEMA tutorial**](https://docs.google.com/presentation/d/1lVH23DPa2NDNBhVvOTRoip8mraw8zfw8VQwbK4vkB1U/edit?usp=sharing) as a Google Slides file.
 
 ## A container-based tool
 
@@ -217,7 +212,7 @@ In case you are working on Singularity, you may implement both these steps with 
 by running:
 
 ```bash
-singularity run -B /<path_to_analysis_directory>/:/mnt/analysis /<path_to>/pema_v.2.1.4.sif
+singularity run -B /<path_to_analysis_directory>/:/mnt/analysis /<path_to>/pema_v.2.1.5.sif
 ```
 
 The `pema_v.2.1.4.sif` may be called differently according to the pema version you 're using.
@@ -225,9 +220,6 @@ The `pema_v.2.1.4.sif` may be called differently according to the pema version y
 
 
 > For further information, you can always check on [PEMA's website](https://hariszaf.github.io/pema_documentation/2.running_general/).
-
-
-
 
 
 
@@ -263,6 +255,7 @@ The tools & databases that PEMA uses are:
 * BigDataScript programming language - https://pcingola.github.io/BigDataScript/
 * FASTQC - https://www.bioinformatics.babraham.ac.uk/projects/fastqc/
 * Trimmomatic - http://www.usadellab.org/cms/?page=trimmomatic
+* fastp - https://github.com/OpenGene/fastp
 * Cutadapt - https://cutadapt.readthedocs.io/en/stable/
 * BayesHammer - included in SPAdes - http://cab.spbu.ru/software/spades/
 * PANDAseq - https://github.com/neufeld/pandaseq

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ or Docker on your computing environment.
 In case you are working on Singularity, you may run the following command to get the PEMA Singularity image:
 
 ```
- singularity pull pema_v.2.1.4.sif https://gitlab.com/microbactions/pema-singularity-images-v.2.1.4/-/raw/main/pema_v.2.1.4.sif 
+ singularity pull pema_v.2.1.5.sif https://gitlab.com/microbactions/pema-singularity-images-v.2.1.5/-/raw/main/pema_v.2.1.5.sif 
 ```
 
 This will take some time but once it's downloaded you have PEMA ready to go!
@@ -113,7 +113,7 @@ This will take some time but once it's downloaded you have PEMA ready to go!
 
 Similarly, in case you are working on Docker you need to run: 
 ```bash=
-docker pull hariszaf/pema:v.2.1.4
+docker pull hariszaf/pema:v.2.1.5
 ```
 instead.
 
@@ -136,7 +136,7 @@ In the *analysis directory*, you need to add the following **mandatory** files:
 
    * the [***parameters.tsv***](https://github.com/hariszaf/pema/blob/master/analysis_directory/parameters.tsv) file 
    (you can download it from this repository and then **complete it** according to the needs of your analysis) 
-   > **ATTENTION!** You always need to check that you have the corresponding version of the parameters file with the pema version you are about to use! For example, if you are about to use `pema:v.2.1.4` then, your parameters file needs to be the [`v.2.1.4`](https://github.com/hariszaf/pema/blob/ARMS/analysis_directory/parameters.tsv) 
+   > **ATTENTION!** You always need to check that you have the corresponding version of the parameters file with the pema version you are about to use! For example, if you are about to use `pema:v.2.1.5` then, your parameters file needs to be the [`v.2.1.5`](https://github.com/hariszaf/pema/blob/ARMS/analysis_directory/parameters.tsv) 
 
    * a subdirectory called ***mydata*** where your .fastq.gz files will be located <br />
 
@@ -215,7 +215,7 @@ by running:
 singularity run -B /<path_to_analysis_directory>/:/mnt/analysis /<path_to>/pema_v.2.1.5.sif
 ```
 
-The `pema_v.2.1.4.sif` may be called differently according to the pema version you 're using.
+The `pema_v.2.1.5.sif` may be called differently according to the pema version you 're using.
 
 
 

--- a/analysis_directory/parameters.tsv
+++ b/analysis_directory/parameters.tsv
@@ -1,678 +1,678 @@
-#= pema_version: 2.1.5
+## pema_version: 2.1.5
 #   --------------------------         GENERAL PARAMETERS       --------------------------
 #
-#=     gene:
-#=        title: marker gene
-#=        description: Indicates the marker gene of the study. Currently PEMA supports the analysis of 16S, 12S, 18S, ITS and COI marker genes. Add the name of the marker gene after the underscore ("_")
-#=        type: string
-#=        required: True
-#=        validation:
-#=          - regex: /^gene_(COI|16S|18S|12S|ITS)$/
-gene	gene_ITS
+##     gene:
+##        title: marker gene
+##        description: Indicates the marker gene of the study. Currently PEMA supports the analysis of 16S, 12S, 18S, ITS and COI marker genes. Add the name of the marker gene after the underscore ("_")
+##        type: string
+##        required: True
+##        validation:
+##          - regex: /^gene_(COI|16S|18S|12S|ITS)$/
+gene=gene_ITS
 #
-#=     outputFolderName:
-#=        title: output folder name
-#=        description: Name of the output folder PEMA will save its results
-#=        type: string
-#=        required: True
-outputFolderName	test_its_fastp_swarm_cut
+##     outputFolderName:
+##        title: output folder name
+##        description: Name of the output folder PEMA will save its results
+##        type: string
+##        required: True
+outputFolderName=test_its_fastp_swarm_cut
 #
-#=     EnaData:
-#=        title: ENA data format
-#=        description: PEMA requires the names of the samples to be in ENA format (e.g "ERR1021912_1.fastq.gz"). In that case EnaData would be "Yes". Otherwise, if the raw data are as returned by the Illumina sequencer PEMA has to make this convertion (EnaData: No) and it will return a mapping file linking the initial filenames to those created for the analysis.
-#=        type: boolean
-#=        required: True
-#=        validation: 
-#=          - value: Yes
-#=          - value: No
-EnaData	Yes
+##     EnaData:
+##        title: ENA data format
+##        description: PEMA requires the names of the samples to be in ENA format (e.g "ERR1021912_1.fastq.gz"). In that case EnaData would be "Yes". Otherwise, if the raw data are as returned by the Illumina sequencer PEMA has to make this convertion (EnaData: No) and it will return a mapping file linking the initial filenames to those created for the analysis.
+##        type: boolean
+##        required: True
+##        validation: 
+##          - value: Yes
+##          - value: No
+EnaData=Yes
 #
-#=     sequencerPrefix:
-#=        title: sequencer prefix
-#=        description: Each sequencer has a special combination of letters with which all its reads start with (e.g., "@M0"). Please provide this pattern if the EnaData is "No". 
-#=        type: string
-#=        required: True
-sequencerPrefix	M0
+##     sequencerPrefix:
+##        title: sequencer prefix
+##        description: Each sequencer has a special combination of letters with which all its reads start with (e.g., "@M0"). Please provide this pattern if the EnaData is "No". 
+##        type: string
+##        required: True
+sequencerPrefix=M0
 #
 # ------------------------------------     PRE-PROCESSING : APPROACH     ------------------------------------
 #
-#=     preprocess:
-#=        title: preprocess approach
-#=        description: Since the v.2.1.5 of PEMA the user may choose between either the initial PEMA implementation for pre-processing (Trimmomatic, pandaseq) or the latest one (fastp). If you choose the original approach (Trimmomatic) you should skip the fastp-related parameters and vice-versa."""
-#=        type: string
-#=        required: True
-#=        validation:
-#=          - value: original
-#=          - value: fastp
-preprocess	fastp
+##     preprocess:
+##        title: preprocess approach
+##        description: Since the v.2.1.5 of PEMA the user may choose between either the initial PEMA implementation for pre-processing (Trimmomatic, pandaseq) or the latest one (fastp). If you choose the original approach (Trimmomatic) you should skip the fastp-related parameters and vice-versa."""
+##        type: string
+##        required: True
+##        validation:
+##          - value: original
+##          - value: fastp
+preprocess=fastp
 #
 #   --------------------------     PRE-PROCESSING PARAMETERS : fastp     --------------------------
 #
-#=     fastpThreads:
-#=        title: fastp threads
-#=        description: Number of threads to be used by fastp
-#=        type: integer
-#=        required: False
-fastpThreads	3
+##     fastpThreads:
+##        title: fastp threads
+##        description: Number of threads to be used by fastp
+##        type: integer
+##        required: False
+fastpThreads=3
 #
-#=     disable_adapter_trimming:
-#=        title:
-#=        description: Adapter trimming is enabled by default. If this option is specified, adapter trimming is disabled
-#=        type: boolean
-#=        required: False
-disable_adapter_trimming	True
+##     disable_adapter_trimming:
+##        title:
+##        description: Adapter trimming is enabled by default. If this option is specified, adapter trimming is disabled
+##        type: boolean
+##        required: False
+disable_adapter_trimming=True
 #
-#=     detect_adapter_for_pe:
-#=        title:
-#=        description: Adapter sequence auto-detection.
-#=        type: boolean
-#=        required:
-detect_adapter_for_pe	False
+##     detect_adapter_for_pe:
+##        title:
+##        description: Adapter sequence auto-detection.
+##        type: boolean
+##        required:
+detect_adapter_for_pe=False
 #
-#=     adapter_sequence:
-#=        title:
-#=        description: the adapter for read1.This is used if R1/R2 are found not overlapped.
-#=        type: string
-#=        required: False
-#=        validation:
-#=          -value: {A, T, C, G}*n
-adapter_sequence	"ATCCTC"
+##     adapter_sequence:
+##        title:
+##        description: the adapter for read1.This is used if R1/R2 are found not overlapped.
+##        type: string
+##        required: False
+##        validation:
+##          -value: {A, T, C, G}*n
+adapter_sequence="ATCCTC"
 #
-#=     adapter_sequence_r2:
-#=        title:
-#=        description: the adapter for read2. This is used if R1/R2 are found not overlapped. If not specified, it will be the same as <adapter_sequence>.
-#=        type: string
-#=        required: False
-#=        validation:
-#=         -value: {A, T, C, G}*n
-adapter_sequence_r2	"ATCCTC"
+##     adapter_sequence_r2:
+##        title:
+##        description: the adapter for read2. This is used if R1/R2 are found not overlapped. If not specified, it will be the same as <adapter_sequence>.
+##        type: string
+##        required: False
+##        validation:
+##         -value: {A, T, C, G}*n
+adapter_sequence_r2="ATCCTC"
 #
-#=     correction:
-#=        title: Enable base correction in overlapped regions, default is disabled.
-#=        description:
-#=        type:
-#=        required: False
-correction	True
+##     correction:
+##        title: Enable base correction in overlapped regions, default is disabled.
+##        description:
+##        type:
+##        required: False
+correction=True
 #
-#=     overrepresentation_analysis:
-#=        title:
-#=        description: enable overrepresented sequence analysis; for a description of the analysis see https://doi.org/10.1093/bioinformatics/bty560  
-#=        type:
-#=        required: False
-overrepresentation_analysis	False
+##     overrepresentation_analysis:
+##        title:
+##        description: enable overrepresented sequence analysis; for a description of the analysis see https://doi.org/10.1093/bioinformatics/bty560  
+##        type:
+##        required: False
+overrepresentation_analysis=False
 #
-#=     overrepresentation_sampling:
-#=        title:
-#=        description: One in (--overrepresentation_sampling) reads will be computed for overrepresentation analysis (1~10000), smaller is slower, default is 20.
-#=        type: integer
-#=        required: False
-overrepresentation_sampling	20 
+##     overrepresentation_sampling:
+##        title:
+##        description: One in (--overrepresentation_sampling) reads will be computed for overrepresentation analysis (1~10000), smaller is slower, default is 20.
+##        type: integer
+##        required: False
+overrepresentation_sampling=20 
 #
-#=     overlap_diff_percent_limit
-#=        title:
-#=        description: The maximum percentage of mismatched bases to detect overlapped region of PE reads. This will affect overlap analysis based PE merge, adapter trimming and correction. Default 20 means 20%.
-#=        type: integer
-#=        required: False
-overlap_diff_percent_limit	20
+##     overlap_diff_percent_limit
+##        title:
+##        description: The maximum percentage of mismatched bases to detect overlapped region of PE reads. This will affect overlap analysis based PE merge, adapter trimming and correction. Default 20 means 20%.
+##        type: integer
+##        required: False
+overlap_diff_percent_limit=20
 #
-#=      complexity_threshold:
-#=         title:
-#=         description: The threshold for low complexity filter (0~100). Default is 30, which means 30% complexity is required. 
-#=         type: integer
-#=         required: False
-complexity_threshold	30
+##      complexity_threshold:
+##         title:
+##         description: The threshold for low complexity filter (0~100). Default is 30, which means 30% complexity is required. 
+##         type: integer
+##         required: False
+complexity_threshold=30
 #
-#=     length_required:
-#=        title:
-#=        description: Reads shorter than length_required will be discarded, default is 15.
-#=        type: integer
-#=        required: False
-length_required	100
+##     length_required:
+##        title:
+##        description: Reads shorter than length_required will be discarded, default is 15.
+##        type: integer
+##        required: False
+length_required=100
 #
-#=      n_base_limit:
-#=         title:
-#=         description: If one read's number of N base is >n_base_limit, then this read/pair is discarded. Default is 5.
-#=         type:
-#=         required:
-n_base_limit	5
+##      n_base_limit:
+##         title:
+##         description: If one read's number of N base is >n_base_limit, then this read/pair is discarded. Default is 5.
+##         type:
+##         required:
+n_base_limit=5
 #
-#=     cut_front:
-#=        title:
-#=        description: Move a sliding window from front (5') to tail, drop the bases in the window if its mean quality < threshold, stop otherwise.
-#=        type:
-#=        required:
-cut_front	False
+##     cut_front:
+##        title:
+##        description: Move a sliding window from front (5') to tail, drop the bases in the window if its mean quality < threshold, stop otherwise.
+##        type:
+##        required:
+cut_front=False
 #
-#=     cut_front_mean_quality:
-#=        title:
-#=        description: The mean quality requirement option for cut_front. Range: 1~36 default: 20 (Q20).
-#=        type: integer
-#=        required: False
-cut_front_mean_quality	20
+##     cut_front_mean_quality:
+##        title:
+##        description: The mean quality requirement option for cut_front. Range: 1~36 default: 20 (Q20).
+##        type: integer
+##        required: False
+cut_front_mean_quality=20
 #
-#=     cut_front_window_size:
-#=        title:
-#=        description: The window size option of cut_front. Range: 1~1000, default: 4.
-#=        type: integer
-#=        required: False
-cut_front_window_size	4
+##     cut_front_window_size:
+##        title:
+##        description: The window size option of cut_front. Range: 1~1000, default: 4.
+##        type: integer
+##        required: False
+cut_front_window_size=4
 #
-#=     cut_tail:
-#=        title:
-#=        description: Move a sliding window from tail (3') to front, drop the bases in the window if its mean quality < threshold, stop otherwise.
-#=        type: boolean
-#=        required: False
-cut_tail	False
+##     cut_tail:
+##        title:
+##        description: Move a sliding window from tail (3') to front, drop the bases in the window if its mean quality < threshold, stop otherwise.
+##        type: boolean
+##        required: False
+cut_tail=False
 #
-#=     cut_tail_window_size:
-#=        title:
-#=        description: The window size option of cut_tail. Range: 1~1000, default: 4.
-#=        type: integer
-#=        required: False
-cut_tail_window_size	4
+##     cut_tail_window_size:
+##        title:
+##        description: The window size option of cut_tail. Range: 1~1000, default: 4.
+##        type: integer
+##        required: False
+cut_tail_window_size=4
 #
-#=     cut_tail_mean_quality:
-#=        title:
-#=        description: The mean quality requirement option for cut_tail. Range: 1~36 default: 20 (Q20)
-#=        type: integer
-#=        required: False
-cut_tail_mean_quality	20
+##     cut_tail_mean_quality:
+##        title:
+##        description: The mean quality requirement option for cut_tail. Range: 1~36 default: 20 (Q20)
+##        type: integer
+##        required: False
+cut_tail_mean_quality=20
 #
-#=     cut_right:
-#=        title:
-#=        description: Move a sliding window from front to tail, if meet one window with mean quality < threshold, drop the bases in the window and the right part, and then stop.
-#=        type: boolean
-#=        required: False
-cut_right	False
+##     cut_right:
+##        title:
+##        description: Move a sliding window from front to tail, if meet one window with mean quality < threshold, drop the bases in the window and the right part, and then stop.
+##        type: boolean
+##        required: False
+cut_right=False
 #
-#=     cut_right_window_size:
-#=        title:
-#=        description: The window size option of cut_right. Range: 1~1000, default: 4.
-#=        type: integer
-#=        required: False
-cut_right_window_size	5
+##     cut_right_window_size:
+##        title:
+##        description: The window size option of cut_right. Range: 1~1000, default: 4.
+##        type: integer
+##        required: False
+cut_right_window_size=5
 #
-#=     cut_right_mean_quality:
-#=        title:
-#=        description: The mean quality requirement option for cut_right. Range: 1~36 default: 20 (Q20)
-#=        type: integer
-#=        required: False
-cut_right_mean_quality	20
+##     cut_right_mean_quality:
+##        title:
+##        description: The mean quality requirement option for cut_right. Range: 1~36 default: 20 (Q20)
+##        type: integer
+##        required: False
+cut_right_mean_quality=20
 #
 #
 #   --------------------------     PRE-PROCESSING PARAMETERS : original approach     --------------------------
 #
 #   --------------------------     PRE-PROCESSING PARAMETERS : Trimmomatic     --------------------------
 #
-#=     maxInfo:
-#=        title: maximum information
-#=        description: A Trimmomatic parameter. When enabled, it performs an adaptive quality trim, balancing the benefits of retaining longer reads against the costs of retaining bases with errors.
-#=        type: boolean
-#=        required: True
-#=        validation: 
-#=          - value: Yes
-#=          - value: No
-maxInfo	Yes
+##     maxInfo:
+##        title: maximum information
+##        description: A Trimmomatic parameter. When enabled, it performs an adaptive quality trim, balancing the benefits of retaining longer reads against the costs of retaining bases with errors.
+##        type: boolean
+##        required: True
+##        validation: 
+##          - value: Yes
+##          - value: No
+maxInfo=Yes
 #
-#=     targetLength:
-#=        title: maximum information
-#=        description: A Trimmomatic parameter. Specifies the read length which is likely to allow the location of the read within the target sequence to be determined.
-#=        type: integer
-#=        required: True
-#=        validation: 
-#=          - range: 
-#=            min: 1
-targetLength	100
+##     targetLength:
+##        title: maximum information
+##        description: A Trimmomatic parameter. Specifies the read length which is likely to allow the location of the read within the target sequence to be determined.
+##        type: integer
+##        required: True
+##        validation: 
+##          - range: 
+##            min: 1
+targetLength=100
 #
-#=     strictness:
-#=        title: strictness
-#=        description: A Trimmomatic parameter. Specifies the balance between preserving as much read length as possible vs. removal of incorrect bases. A low value of this parameter (<0.2) favours longer reads, while a high value (>0.8) favours read correctness.
-#=        type: float
-#=        required: True
-#=        validation:
-#=          - range:
-#=            min: 0.0
-#=            max: 1.0
-strictness	0.8
+##     strictness:
+##        title: strictness
+##        description: A Trimmomatic parameter. Specifies the balance between preserving as much read length as possible vs. removal of incorrect bases. A low value of this parameter (<0.2) favours longer reads, while a high value (>0.8) favours read correctness.
+##        type: float
+##        required: True
+##        validation:
+##          - range:
+##            min: 0.0
+##            max: 1.0
+strictness=0.8
 #
-#=     adapters:
-#=        title: adapters
-#=        description: A Trimmomatic parameter. Suggested adapter sequences are provided for TruSeq2 (as used in GAII machines) and TruSeq3 (as used by HiSeq and MiSeq machines),
-#=        type: string
-#=        required: True
-adapters	adapters_combined_152_unique.fasta
+##     adapters:
+##        title: adapters
+##        description: A Trimmomatic parameter. Suggested adapter sequences are provided for TruSeq2 (as used in GAII machines) and TruSeq3 (as used by HiSeq and MiSeq machines),
+##        type: string
+##        required: True
+adapters=adapters_combined_152_unique.fasta
 #
-#=     seedMismatches:
-#=        title: adapters
-#=        description: A Trimmomatic parameter. Specifies the maximum mismatch count which will still allow a full match to be performed.
-#=        type: integer
-#=        required: True 
-#=        validation: 
-#=          - range: 
-#=            min: 0 
-seedMismatches	0
+##     seedMismatches:
+##        title: adapters
+##        description: A Trimmomatic parameter. Specifies the maximum mismatch count which will still allow a full match to be performed.
+##        type: integer
+##        required: True 
+##        validation: 
+##          - range: 
+##            min: 0 
+seedMismatches=0
 #
-#=     palindromeClipThreshold:
-#=        title: adapters
-#=        description: A Trimmomatic parameter. Specifies how accurate the match between the two 'adapter ligated' reads must be for PE palindrome read alignment.
-#=        type: integer
-#=        required: True
-#=        validation: 
-#=          - range: 
-#=            min: 1 
-palindromeClipThreshold	20
+##     palindromeClipThreshold:
+##        title: adapters
+##        description: A Trimmomatic parameter. Specifies how accurate the match between the two 'adapter ligated' reads must be for PE palindrome read alignment.
+##        type: integer
+##        required: True
+##        validation: 
+##          - range: 
+##            min: 1 
+palindromeClipThreshold=20
 #
-#=     simpleClipThreshold:
-#=        title: simple ClipThreshold
-#=        description: A Trimmomatic parameter. Specifies how accurate the match between any adapter etc. sequence must be against a read.
-#=        type: integer
-#=        required: True
-#=        validation:
-#=          - range: 
+##     simpleClipThreshold:
+##        title: simple ClipThreshold
+##        description: A Trimmomatic parameter. Specifies how accurate the match between any adapter etc. sequence must be against a read.
+##        type: integer
+##        required: True
+##        validation:
+##          - range: 
 #-             min: 0 
-simpleClipThreshold	30
+simpleClipThreshold=30
 #
-#=     leading:
-#=        title: simple ClipThreshold
-#=        description: A Trimmomatic parameter. Removes low quality bases from the beginning. As long as a base has a value below this threshold (value of the 'leading' parameter) the base is removed and the next base will be investigated.
-#=        type: integer
-#=        required: True
-#=        validation: 
-#=          - range: 
-#=            min: 0 
-leading	20
+##     leading:
+##        title: simple ClipThreshold
+##        description: A Trimmomatic parameter. Removes low quality bases from the beginning. As long as a base has a value below this threshold (value of the 'leading' parameter) the base is removed and the next base will be investigated.
+##        type: integer
+##        required: True
+##        validation: 
+##          - range: 
+##            min: 0 
+leading=20
 #
-#=     trailing:
-#=        title: trailing
-#=        description: A Trimmomatic parameter. Removes low quality bases from the end. As long as a base has a value below this threshold (value of the 'trailing' parameter), the base is removed and the next base (which as Trimmomatic is starting from the 3' prime end, would be base preceding the just removed base) will be investigated.
-#=        type: integer
-#=        required: True
-#=        validation: 
-#=          - range: 
-#=            min: 0 
-trailing	2
+##     trailing:
+##        title: trailing
+##        description: A Trimmomatic parameter. Removes low quality bases from the end. As long as a base has a value below this threshold (value of the 'trailing' parameter), the base is removed and the next base (which as Trimmomatic is starting from the 3' prime end, would be base preceding the just removed base) will be investigated.
+##        type: integer
+##        required: True
+##        validation: 
+##          - range: 
+##            min: 0 
+trailing=2
 #
-#=     minlen:
-#=        title: minimum length of the amplicon
-#=        description: A Trimmomatic parameter. Removes reads that fall below the specified minimal length.
-#=        type: integer
-#=        required: True
-#=        validation: 
-#=          - range: 
-#=            min: 1
-minlen	100
+##     minlen:
+##        title: minimum length of the amplicon
+##        description: A Trimmomatic parameter. Removes reads that fall below the specified minimal length.
+##        type: integer
+##        required: True
+##        validation: 
+##          - range: 
+##            min: 1
+minlen=100
 #
-#=     threadsTrimmomatic:
-#=        title: minimum length of the amplicon
-#=        description: A Trimmomatic parameter. Set how many threads you want Trimmomatic to run into.
-#=        type: integer
-#=        required: True
-#=        validation: 
-#=          - range: 
-#=            min: 0 
-threadsTrimmomatic	8
+##     threadsTrimmomatic:
+##        title: minimum length of the amplicon
+##        description: A Trimmomatic parameter. Set how many threads you want Trimmomatic to run into.
+##        type: integer
+##        required: True
+##        validation: 
+##          - range: 
+##            min: 0 
+threadsTrimmomatic=8
 #
 #
 #   --------------------------     PRE-PROCESSING PARAMETERS : PANDAseq     --------------------------
 #
-#=     pandaseqAlgorithm:
-#=        title: minimum length of the amplicon
-#=        description: Merging algorithm of the PANDAseq parameter. The user might select among the `simple_bayesian` (Masella 2012), the `pear` (Zhang 2013), the `stich` and the `flash` algorithms.
-#=        type: string
-#=        required: True
-#=        validation: 
-#=          - value: simple_bayesian
-#=          - value: pear 
-#=          - value: stich
-#=          - value: flash
-pandaseqAlgorithm	simple_bayesian
+##     pandaseqAlgorithm:
+##        title: minimum length of the amplicon
+##        description: Merging algorithm of the PANDAseq parameter. The user might select among the `simple_bayesian` (Masella 2012), the `pear` (Zhang 2013), the `stich` and the `flash` algorithms.
+##        type: string
+##        required: True
+##        validation: 
+##          - value: simple_bayesian
+##          - value: pear 
+##          - value: stich
+##          - value: flash
+pandaseqAlgorithm=simple_bayesian
 #
-#=     pandaseqThreads:
-#=        title: pandaseq threads
-#=        description: Set number of threads to be used from pandaseq. PANDAseq is a I/O bound algorithm. That means that it needs severous time in order to handle the ipnut and output files. while the process is quite fast. However, it does support multithreading and here you can set the number of threads it is going to use.
-#=        type: integer
-#=        required: True
-#=        validation:
-#=          - range:
-#=            min: 0
-pandaseqThreads	8
+##     pandaseqThreads:
+##        title: pandaseq threads
+##        description: Set number of threads to be used from pandaseq. PANDAseq is a I/O bound algorithm. That means that it needs severous time in order to handle the ipnut and output files. while the process is quite fast. However, it does support multithreading and here you can set the number of threads it is going to use.
+##        type: integer
+##        required: True
+##        validation:
+##          - range:
+##            min: 0
+pandaseqThreads=8
 #
-#=     pandaseqMinlen:
-#=        title: pandaseq minimum length
-#=        description: Sets the minimum length for a sequence, after primers are removed. By default, all sequences are kept. With this option, sequences shorter than desired can be discarded. In case you need to use this parameter, be sure you leave a tab after 'minlen' and set it like this: '-l 80'. If you do not want to use this parameter, make sure there is nothing after 'minlen'.
-#=        type: integer
-#=        required: True
-#=        validation: 
-#=          - range: 
-#=            min: 0 
-pandaseqMinlen	
+##     pandaseqMinlen:
+##        title: pandaseq minimum length
+##        description: Sets the minimum length for a sequence, after primers are removed. By default, all sequences are kept. With this option, sequences shorter than desired can be discarded. In case you need to use this parameter, be sure you leave a tab after 'minlen' and set it like this: '-l 80'. If you do not want to use this parameter, make sure there is nothing after 'minlen'.
+##        type: integer
+##        required: True
+##        validation: 
+##          - range: 
+##            min: 0 
+pandaseqMinlen=
 #
-#=     minoverlap:
-#=        title: pandaseq minimum overlap
-#=        description: Sets the minimum overlap between forward and reverse reads. Raising this number does not generally increase the quality of the output as alignments with small overlaps tend to score poorly and are discarded anyway.
-#=        type: integer
-#=        required: True
-#=        validation:
-#=          - range: 
-#=            min: 0
-minoverlap	1 
+##     minoverlap:
+##        title: pandaseq minimum overlap
+##        description: Sets the minimum overlap between forward and reverse reads. Raising this number does not generally increase the quality of the output as alignments with small overlaps tend to score poorly and are discarded anyway.
+##        type: integer
+##        required: True
+##        validation:
+##          - range: 
+##            min: 0
+minoverlap=1 
 #
-#=     threshold:
-#=        title: threshold
-#=        description: Sets the score, that a sequence must meet to be kept in the output. Any alignments lower than this will be discarded as low quality. Increasing this number will not necessarily prevent uncalled bases (Ns) from appearing in the final sequence. It is also used as the threshold to match primers, if primers are supplied.
-#=        type: float
-#=        required: True
-#=        validation:
-#=            - range: 
-#=              min:  0.0
-#=              max: 1.0
-threshold	0.6 
+##     threshold:
+##        title: threshold
+##        description: Sets the score, that a sequence must meet to be kept in the output. Any alignments lower than this will be discarded as low quality. Increasing this number will not necessarily prevent uncalled bases (Ns) from appearing in the final sequence. It is also used as the threshold to match primers, if primers are supplied.
+##        type: float
+##        required: True
+##        validation:
+##            - range: 
+##              min:  0.0
+##              max: 1.0
+threshold=0.6 
 #
-#=     elimination:
-#=        title: elimination
-#=        description: The '-N' parameter eliminates all sequences with uncalled nucleotides in the output. Otherwise, during assembly, uncalled bases (Ns) from unpaired regions may be emitted. If you need -N to be on your analysis, please add '-N' after 'elimination'. Please make sure you leave a tab. If you do not want the parameter to be on, please make sure there is nothing after the 'elimination' parameter.
-#=        type: string
-#=        required: True
-#=        validation: 
-#=          - value: ''
-#=          - value: -N
-elimination	
+##     elimination:
+##        title: elimination
+##        description: The '-N' parameter eliminates all sequences with uncalled nucleotides in the output. Otherwise, during assembly, uncalled bases (Ns) from unpaired regions may be emitted. If you need -N to be on your analysis, please add '-N' after 'elimination'. Please make sure you leave a tab. If you do not want the parameter to be on, please make sure there is nothing after the 'elimination' parameter.
+##        type: string
+##        required: True
+##        validation: 
+##          - value: ''
+##          - value: -N
+elimination=
 #
 #   --------------------------        CLUSTERING PARAMETERS           --------------------------
 #
-#=     clusteringAlgo:
-#=        title: clustering algorithm
-#=        description: For OTU clustering PEMA invokes the vsearch algorithm while for ASVs inference the Swarm. Select which way to go.  
-#=        type: string
-#=        required: True
-#=        validation:
-#=          - value: algo_Swarm
-#=          - value: algo_vsearch
-clusteringAlgo	algo_Swarm
+##     clusteringAlgo:
+##        title: clustering algorithm
+##        description: For OTU clustering PEMA invokes the vsearch algorithm while for ASVs inference the Swarm. Select which way to go.  
+##        type: string
+##        required: True
+##        validation:
+##          - value: algo_Swarm
+##          - value: algo_vsearch
+clusteringAlgo=algo_Swarm
 #
 #   --------------------------     CLUSTERING PARAMETERS : VSEARCH     --------------------------
 #
-#=     vsearchThreads:
-#=        title: vsearch threads
-#=        description: Set the number of threads PANDAseq to use.
-#=        type: integer
-#=        required: True
-#=        validation:
-#=          - range: 
-#=            min: 0
-vsearchThreads	8
+##     vsearchThreads:
+##        title: vsearch threads
+##        description: Set the number of threads PANDAseq to use.
+##        type: integer
+##        required: True
+##        validation:
+##          - range: 
+##            min: 0
+vsearchThreads=8
 #
-#=     vsearchId:
-#=        title: vsearch threads
-#=        description: Set a score about the clustering step of the VSEARCH algorithm. Do not add a read into a certain cluster if the pairwise identity with its centroid, is lower than the value of the 'vsearchId' parameter. The pairwise identity is defined as the number of (matching columns) / (alignment length - terminal gaps).
-#=        type: float
-#=        required: True
-#=        validation:
-#=          - range: 
-#=            min: 0.0
-#=            max: 1.0
-vsearchId	0.95
+##     vsearchId:
+##        title: vsearch threads
+##        description: Set a score about the clustering step of the VSEARCH algorithm. Do not add a read into a certain cluster if the pairwise identity with its centroid, is lower than the value of the 'vsearchId' parameter. The pairwise identity is defined as the number of (matching columns) / (alignment length - terminal gaps).
+##        type: float
+##        required: True
+##        validation:
+##          - range: 
+##            min: 0.0
+##            max: 1.0
+vsearchId=0.95
 #
 #   --------------------------     CLUSTERING PARAMETERS : Swarm     --------------------------
 #
-#=     d:
-#=        title: d
-#=        description: Maximum number of differences allowed between two amplicons, meaning that two amplicons will be grouped if they hav e integer (or less) differences.
-#=        type: integer
-#=        required: True
-#=        validation:
-#=          - range: 
-#=            min: 0 
-d	3
+##     d:
+##        title: d
+##        description: Maximum number of differences allowed between two amplicons, meaning that two amplicons will be grouped if they hav e integer (or less) differences.
+##        type: integer
+##        required: True
+##        validation:
+##          - range: 
+##            min: 0 
+d=3
 #
-#=     boundary:
-#=        title: boundary
-#=        description: By default, an ASV with a mass of 3 or more is considered large. Conversely, an ASV is small if it has a mass of less than 3, meaning that it is composed of either one amplicon of abundance 2, or two amplicons of abundance 1. Any positive value greater than 1 can be specified. Using higher boundary values will speed up the second pass, but also reduce the taxonomical resolution of swarm results.
-#=        type: integer
-#=        required: True
-#=        validation:
-#=          - range: 
-#=            min: 0
-boundary	
+##     boundary:
+##        title: boundary
+##        description: By default, an ASV with a mass of 3 or more is considered large. Conversely, an ASV is small if it has a mass of less than 3, meaning that it is composed of either one amplicon of abundance 2, or two amplicons of abundance 1. Any positive value greater than 1 can be specified. Using higher boundary values will speed up the second pass, but also reduce the taxonomical resolution of swarm results.
+##        type: integer
+##        required: True
+##        validation:
+##          - range: 
+##            min: 0
+boundary=
 #
-#=     swarmThreads:
-#=        title: swarmThreads
-#=        description: The number of threads (CPUs) the Swarm algorithm is allowed to use
-#=        type: integer
-#=        required: True
-#=        validation:
-#=          - range: 
-#=            min: 1
-swarmThreads	3
+##     swarmThreads:
+##        title: swarmThreads
+##        description: The number of threads (CPUs) the Swarm algorithm is allowed to use
+##        type: integer
+##        required: True
+##        validation:
+##          - range: 
+##            min: 1
+swarmThreads=3
 #
 #  -----------------------------     OLIGOTONS        -------------------------------------
 #
-#=     removeOligotons:
-#=        title: removeOligotons
-#=        description:  Remove the oligotons (OTUs that appear with an abuncance less that numOligotons) ?
-#=        type: boolean
-#=        required: True
-#=        validation:
-#=          - value: Yes
-#=          - value: No
-removeOligotons	Yes
+##     removeOligotons:
+##        title: removeOligotons
+##        description:  Remove the oligotons (OTUs that appear with an abuncance less that numOligotons) ?
+##        type: boolean
+##        required: True
+##        validation:
+##          - value: Yes
+##          - value: No
+removeOligotons=Yes
 #
-#=     numOligotons:
-#=        title: numOligotons
-#=        description:  The minimum number of reads that have been clustered under the same OTUs in order not to skip that OTU
-#=        type: integer
-#=        required: True
-#=        validation:
-#=          - range: 
-#=            min: 1
-numOligotons	5
+##     numOligotons:
+##        title: numOligotons
+##        description:  The minimum number of reads that have been clustered under the same OTUs in order not to skip that OTU
+##        type: integer
+##        required: True
+##        validation:
+##          - range: 
+##            min: 1
+numOligotons=5
 #
 #
 #   --------------------------     CLASSIFIER       --------------------------
 #
-#=     classifierAlgo:
-#=        title: classifier algorithm
-#=        description:  """Select classifier for the taxonomy assignment step.
-#=                      If you have 16S, 18S, ITS you should choose CREST. If you have COI, 12S you should choose RDPClassifier. 
-#=                      If you are about to use custom reference database, please make sure you are following the instructions described here  https://hariszaf.github.io/pema_documentation/training_crest_classifier/ (for CREST) and here https://hariszaf.github.io/pema_documentation/training_rdpclassifier/ (for RDPClassifier)."""
-#=        type: string
-#=        required: True
-#=        validation:
-#=          - value: RDPClassifier
-#=          - value: CREST
-classifierAlgo	CREST
+##     classifierAlgo:
+##        title: classifier algorithm
+##        description:  """Select classifier for the taxonomy assignment step.
+##                      If you have 16S, 18S, ITS you should choose CREST. If you have COI, 12S you should choose RDPClassifier. 
+##                      If you are about to use custom reference database, please make sure you are following the instructions described here  https://hariszaf.github.io/pema_documentation/training_crest_classifier/ (for CREST) and here https://hariszaf.github.io/pema_documentation/training_rdpclassifier/ (for RDPClassifier)."""
+##        type: string
+##        required: True
+##        validation:
+##          - value: RDPClassifier
+##          - value: CREST
+classifierAlgo=CREST
 #
-#=     taxonomyFolderName:
-#=        title: number of cores for PaPaRa
-#=        description: Name of the output folder CREST returns. In case you run an analysis for a second, make sure you change this parameter otherwise PEMA will fail. Parameter required if gene: ['16S', '18S', 'ITS'].
-#=        type: string
-#=        required: True 
-taxonomyFolderName	my_taxon_assign
+##     taxonomyFolderName:
+##        title: number of cores for PaPaRa
+##        description: Name of the output folder CREST returns. In case you run an analysis for a second, make sure you change this parameter otherwise PEMA will fail. Parameter required if gene: ['16S', '18S', 'ITS'].
+##        type: string
+##        required: True 
+taxonomyFolderName=my_taxon_assign
 #
 #
 #   --------------------------     GENE-SPECIFIC : 16S/18S     --------------------------
 #
-#=     taxonomyAssignmentMethod:
-#=        title: vsearch threads
-#=        description: Select between 2 different approaches of taxonomy assignment (alignment & phylogenetic based). Alignment based taxonomy is based on Silva database (versions 128 or 132). a phylogenetic based assignment, by putting 'phylogeny' in this parameter. In the case of phylogeny based taxonomy assignment, a reference tree created by the PEMA group and based on Silva v.128 is used. Parameter required only if gene: gene_16S.
-#=        type: string
-#=        required: True
-#=        validation: 
-#=          - value: alignment
-#=          - value: phylogeny
-taxonomyAssignmentMethod	alignment
+##     taxonomyAssignmentMethod:
+##        title: vsearch threads
+##        description: Select between 2 different approaches of taxonomy assignment (alignment & phylogenetic based). Alignment based taxonomy is based on Silva database (versions 128 or 132). a phylogenetic based assignment, by putting 'phylogeny' in this parameter. In the case of phylogeny based taxonomy assignment, a reference tree created by the PEMA group and based on Silva v.128 is used. Parameter required only if gene: gene_16S.
+##        type: string
+##        required: True
+##        validation: 
+##          - value: alignment
+##          - value: phylogeny
+taxonomyAssignmentMethod=alignment
 #
-#=     numberOfCoresForPapara:
-#=        title: number of cores for PaPaRa
-#=        description: In case of phylogeny based taxonomy assignment, set the number of threads the PaPaRa software will use. The parameeter is required if axonomyAssignmentMethod: phylogeny and gene: gene_16S
-#=        type: integer
-#=        required: True 
-#=        validation:
-#=          - range:
-#=            min: 0
-numberOfCoresForPapara	7
+##     numberOfCoresForPapara:
+##        title: number of cores for PaPaRa
+##        description: In case of phylogeny based taxonomy assignment, set the number of threads the PaPaRa software will use. The parameeter is required if axonomyAssignmentMethod: phylogeny and gene: gene_16S
+##        type: integer
+##        required: True 
+##        validation:
+##          - range:
+##            min: 0
+numberOfCoresForPapara=7
 #
-#=     referenceDb:
-#=        title: reference database 
-#=        description: When you use the alignment-based taxonomy assignment, then the LCAClassifier from the CREST algorithm, uses a Silva version for the assignment. PEMA allows you to choose between the two last version of Silva. Hence, set the "silvaVersion" parameter either as 'silva_128' or as 'silva_132' depending on the version of your choice. In case you are running 18S rRNA data, you may also use the PR2 database, by setting the referenceDb parametera as 'pr2'. The parameter is required if custom_ref_db: No and gene: [gene_16S, 'gene_18S', 'gene_COI']
-#=        type: string
-#=        required: True
-#=        validation: 
-#=          - value: silva_128
-#=          - value: silva_132
-#=          - value: pr2
-#=          - value: midori_1
-#=          - value: midori_2
-referenceDb	midori_1
+##     referenceDb:
+##        title: reference database 
+##        description: When you use the alignment-based taxonomy assignment, then the LCAClassifier from the CREST algorithm, uses a Silva version for the assignment. PEMA allows you to choose between the two last version of Silva. Hence, set the "silvaVersion" parameter either as 'silva_128' or as 'silva_132' depending on the version of your choice. In case you are running 18S rRNA data, you may also use the PR2 database, by setting the referenceDb parametera as 'pr2'. The parameter is required if custom_ref_db: No and gene: [gene_16S, 'gene_18S', 'gene_COI']
+##        type: string
+##        required: True
+##        validation: 
+##          - value: silva_128
+##          - value: silva_132
+##          - value: pr2
+##          - value: midori_1
+##          - value: midori_2
+referenceDb=midori_1
 #
 #   --------------------------     GENE-SPECIFIC : ITS     --------------------------
 #
-#=     cutadapt:
-#=        title: perform a cutadapt script to 
-#=        description: 
-#=        type: string
-#=        required: False
-#=        validation:
-#=          - value: Yes
-#=          - value: No 
-cutadapt	Yes
+##     cutadapt:
+##        title: perform a cutadapt script to 
+##        description: 
+##        type: string
+##        required: False
+##        validation:
+##          - value: Yes
+##          - value: No 
+cutadapt=Yes
 #
-#=     forwardITSPrimer:
-#=        title: forward ITS primer
-#=        description: Provide the forward primer used (only in case of ITS). The parameter is required only in case that gene: gene_ITS.
-#=        type: string
-#=        required: True 
-forwardITSPrimer	GATGAAGAACGYAGYRAA
+##     forwardITSPrimer:
+##        title: forward ITS primer
+##        description: Provide the forward primer used (only in case of ITS). The parameter is required only in case that gene: gene_ITS.
+##        type: string
+##        required: True 
+forwardITSPrimer=GATGAAGAACGYAGYRAA
 #
-#=     reverseITSPrimer:
-#=        title: reverse ITS primer
-#=        description: Provide the reverse primer used (only in case of ITS). The parameter is required only in case that gene: gene_ITS.
-#=        type: string
-#=        required: True 
-reverseITSPrimer	CTBTTVCCKCTTCACTCG
+##     reverseITSPrimer:
+##        title: reverse ITS primer
+##        description: Provide the reverse primer used (only in case of ITS). The parameter is required only in case that gene: gene_ITS.
+##        type: string
+##        required: True 
+reverseITSPrimer=CTBTTVCCKCTTCACTCG
 #
 #   --------------------------     GENE-SPECIFIC : COI     --------------------------
 #
-#=     abskew:
-#=        title: abskew
-#=        description: PEMA invokes the UCHIME_DENOVO3 algorithm for the chimera removal in the case of the COI marker gene. Probably, for environmental studies a low abskew is better, while in more specific studies a larger one would fit most. The parameter is required only if gene: gene_COI
-#=        type: integer
-#=        required: True
-#=        validation:
-#=          - range:
-#=            min: 0
-abskew	2
+##     abskew:
+##        title: abskew
+##        description: PEMA invokes the UCHIME_DENOVO3 algorithm for the chimera removal in the case of the COI marker gene. Probably, for environmental studies a low abskew is better, while in more specific studies a larger one would fit most. The parameter is required only if gene: gene_COI
+##        type: integer
+##        required: True
+##        validation:
+##          - range:
+##            min: 0
+abskew=2
 #
 #   --------------------------     CUSTOM REFERENCE DATABASE     --------------------------
 #
-#=     custom_ref_db:
-#=        title: custom reference database
-#=        description: Use a custom reference database for the taxonomy assignment step. In this case, extra input files are required depending on the classifier the user selected. To see more on how these files should be in case of the RDPClassifier, follow this link: https://hariszaf.github.io/pema_documentation/training_rdpclassifier/. In case that the CREST classifier is be used, follow this link: https://hariszaf.github.io/pema_documentation/training_crest_classifier/. Remember that as containers are lost when exit from one, you will have to train the classifier, every time you run a new PEMA container If you are about to use a custom ref db, set the following parameter as 'Yes'. Otherwise, it must be set as 'No'. The `name_of_custom_db` may be empty or no depending on whether you will use a custom db or not.
-#=        type: boolean
-#=        required: True
-#=        validation:
-#=          - value: Yes
-#=          - value: No
-custom_ref_db	No
+##     custom_ref_db:
+##        title: custom reference database
+##        description: Use a custom reference database for the taxonomy assignment step. In this case, extra input files are required depending on the classifier the user selected. To see more on how these files should be in case of the RDPClassifier, follow this link: https://hariszaf.github.io/pema_documentation/training_rdpclassifier/. In case that the CREST classifier is be used, follow this link: https://hariszaf.github.io/pema_documentation/training_crest_classifier/. Remember that as containers are lost when exit from one, you will have to train the classifier, every time you run a new PEMA container If you are about to use a custom ref db, set the following parameter as 'Yes'. Otherwise, it must be set as 'No'. The `name_of_custom_db` may be empty or no depending on whether you will use a custom db or not.
+##        type: boolean
+##        required: True
+##        validation:
+##          - value: Yes
+##          - value: No
+custom_ref_db=No
 #
-#=     name_of_custom_db:
-#=        title: name of custom database
-#=        description: Name of how custom reference database will be named. Parameter required only if custom_ref_db: Yes
-#=        type: string
-#=        required: True
-name_of_custom_db	
+##     name_of_custom_db:
+##        title: name of custom database
+##        description: Name of how custom reference database will be named. Parameter required only if custom_ref_db: Yes
+##        type: string
+##        required: True
+name_of_custom_db=
 #
 #
 #   --------------------------     PHYLOSEQ - SPECIFIC     --------------------------
 #
-#=     phyloseq:
-#=        title: phyloseq
-#=        description: To use Phyloseq set the following  parameter 'phyloseq' with 'Yes'. Please remember that in order to use phyloseq a "metadata.csv" file is necessary to be part of your anaylis folder. 
-#=        type: boolean
-#=        required: True
-#=        validation:
-#=          - value: Yes
-#=          - value: No
-phyloseq	No
+##     phyloseq:
+##        title: phyloseq
+##        description: To use Phyloseq set the following  parameter 'phyloseq' with 'Yes'. Please remember that in order to use phyloseq a "metadata.csv" file is necessary to be part of your anaylis folder. 
+##        type: boolean
+##        required: True
+##        validation:
+##          - value: Yes
+##          - value: No
+phyloseq=No
 #
-#=     tree:
-#=        title: tree
-#=        description: The phyloseq object can handle phylogenetic trees as well. PEMA uses RAxML-ng in order to build such trees. Do you want to create such a tree with your OTUs? In case you build this once, you can use it as many times as you want. Parameter required if phyloseq: Yes.
-#=        type: boolean
-#=        required: True
-#=        validation:
-#=          - value: Yes
-#=          - value: No
-tree	No
+##     tree:
+##        title: tree
+##        description: The phyloseq object can handle phylogenetic trees as well. PEMA uses RAxML-ng in order to build such trees. Do you want to create such a tree with your OTUs? In case you build this once, you can use it as many times as you want. Parameter required if phyloseq: Yes.
+##        type: boolean
+##        required: True
+##        validation:
+##          - value: Yes
+##          - value: No
+tree=No
 #
-#=     raxmlThreads:
-#=        title: raxml threads
-#=        description: Set the number of threads raxml is allowed to use. Paameter required if phyloseq: Yes and tree: Yes.
-#=        type: integer
-#=        required: True 
-#=        validation:
-#=          - range: 
-#=              min: 0  
-raxmlThreads	5
+##     raxmlThreads:
+##        title: raxml threads
+##        description: Set the number of threads raxml is allowed to use. Paameter required if phyloseq: Yes and tree: Yes.
+##        type: integer
+##        required: True 
+##        validation:
+##          - range: 
+##              min: 0  
+raxmlThreads=5
 #
-#=     parsTrees:
-#=        title: parsimony trees
-#=        description: Number of parsimony trees raxml-ng will go for. Parameter required if phyloseq: Yes and tree: Yes
-#=        type: integer
-#=        required: True
-#=        validation: 
-#=          - range: 
-#=              min: 0 
-parsTrees	5
+##     parsTrees:
+##        title: parsimony trees
+##        description: Number of parsimony trees raxml-ng will go for. Parameter required if phyloseq: Yes and tree: Yes
+##        type: integer
+##        required: True
+##        validation: 
+##          - range: 
+##              min: 0 
+parsTrees=5
 #
-#=     bootstrapTrees:
-#=        title: bootstrap trees
-#=        description: Number of bootstrap trees raxml-ng will go for. Parameter required if phyloseq: Yes and tree: Yes
-#=        type: integer
-#=        required: True 
-#=        validation:
-#=          - range: 
-#=              min: 0 
-bootstrapTrees	5
+##     bootstrapTrees:
+##        title: bootstrap trees
+##        description: Number of bootstrap trees raxml-ng will go for. Parameter required if phyloseq: Yes and tree: Yes
+##        type: integer
+##        required: True 
+##        validation:
+##          - range: 
+##              min: 0 
+bootstrapTrees=5
 #
 #   --------------------------     sum up      --------------------------
 #
-#=     emptyRawDataFile:
-#=        title: empty raw data files 
-#=        description: Move raw data to a new folder
-#=        type: boolean
-#=        required: True
-#=        validation:
-#=          - value: Yes
-#=          - value: No
-emptyRawDataFile	Yes
+##     emptyRawDataFile:
+##        title: empty raw data files 
+##        description: Move raw data to a new folder
+##        type: boolean
+##        required: True
+##        validation:
+##          - value: Yes
+##          - value: No
+emptyRawDataFile=Yes
 #
-#=     emptyCheckpoints:
-#=        title: empty check points
-#=        description: Move all check points returned in a separate folder
-#=        type: boolean
-#=        required: True
-#=        validation: 
-#=          - value: Yes
-#=          - value: No
-emptyCheckpoints	Yes
+##     emptyCheckpoints:
+##        title: empty check points
+##        description: Move all check points returned in a separate folder
+##        type: boolean
+##        required: True
+##        validation: 
+##          - value: Yes
+##          - value: No
+emptyCheckpoints=Yes
 #
-#=     getNCBITaxId:
-#=        title: get NCBI Taxonomy Id
-#=        description: Link the OTU/ASV taxonomy assignment to its closest NCBI Taxonomy Id, meaning if there is no NCBI Taxonomy id at the species level, PEMA will search for the one of the genus and so on. 
-#=        type: boolean
-#=        required: True
-#=        validation: 
-#=          - value: Yes
-#=          - value: No
-getNCBITaxId	Yes
+##     getNCBITaxId:
+##        title: get NCBI Taxonomy Id
+##        description: Link the OTU/ASV taxonomy assignment to its closest NCBI Taxonomy Id, meaning if there is no NCBI Taxonomy id at the species level, PEMA will search for the one of the genus and so on. 
+##        type: boolean
+##        required: True
+##        validation: 
+##          - value: Yes
+##          - value: No
+getNCBITaxId=Yes
 #
 #   --------------------------     PEMA METADATA     --------------------------
 #
 # The following are not to be set by the user but describe each PEMA version
-#=    about:  Configuration file for PEMA :version:. We encourage users to study the manual of each tool and tune these parameters according to their specific experiments
-#=    version: v.2.1.5
-#=    tools: https://github.com/hariszaf/pema/blob/master/help_files/encapsulated_software.md
-#=    databases: https://github.com/hariszaf/pema/blob/master/help_files/encapsulated_software.md
-#=    author: Haris Zafeiropoulos <haris-zaf@hcmr.gr>
-#=    contributors: Christina Pavloudi <cpavloud@hotmail.com>
+##    about:  Configuration file for PEMA :version:. We encourage users to study the manual of each tool and tune these parameters according to their specific experiments
+##    version: v.2.1.5
+##    tools: https://github.com/hariszaf/pema/blob/master/help_files/encapsulated_software.md
+##    databases: https://github.com/hariszaf/pema/blob/master/help_files/encapsulated_software.md
+##    author: Haris Zafeiropoulos <haris-zaf@hcmr.gr>
+##    contributors: Christina Pavloudi <cpavloud@hotmail.com>

--- a/analysis_directory/parameters.tsv
+++ b/analysis_directory/parameters.tsv
@@ -1,23 +1,36 @@
 ## pema_version: 2.1.5
+# In this file the user must define the parameters. The format is:
+#
+# parameter=value
+##       parameter --help
+##           title: title of the parameter
+##           description: a short description
+##           type: Boolean or String or Integer
+##           required: True of False
+##           validation: some extra information regarding the values limits, options
+##               - value:
 #   --------------------------         GENERAL PARAMETERS       --------------------------
 #
-##     gene:
+gene=gene_ITS
+##     gene --help
 ##        title: marker gene
 ##        description: Indicates the marker gene of the study. Currently PEMA supports the analysis of 16S, 12S, 18S, ITS and COI marker genes. Add the name of the marker gene after the underscore ("_")
 ##        type: string
 ##        required: True
 ##        validation:
 ##          - regex: /^gene_(COI|16S|18S|12S|ITS)$/
-gene=gene_ITS
+##   --------------------------
 #
-##     outputFolderName:
+outputFolderName=test_its_fastp_swarm_cut
+##     outputFolderName --help
 ##        title: output folder name
 ##        description: Name of the output folder PEMA will save its results
 ##        type: string
 ##        required: True
-outputFolderName=test_its_fastp_swarm_cut
+##   --------------------------
 #
-##     EnaData:
+EnaData=Yes
+##     EnaData --help
 ##        title: ENA data format
 ##        description: PEMA requires the names of the samples to be in ENA format (e.g "ERR1021912_1.fastq.gz"). In that case EnaData would be "Yes". Otherwise, if the raw data are as returned by the Illumina sequencer PEMA has to make this convertion (EnaData: No) and it will return a mapping file linking the initial filenames to those created for the analysis.
 ##        type: boolean
@@ -25,18 +38,19 @@ outputFolderName=test_its_fastp_swarm_cut
 ##        validation: 
 ##          - value: Yes
 ##          - value: No
-EnaData=Yes
+##   --------------------------
 #
-##     sequencerPrefix:
+sequencerPrefix=M0
+##     sequencerPrefix --help
 ##        title: sequencer prefix
 ##        description: Each sequencer has a special combination of letters with which all its reads start with (e.g., "@M0"). Please provide this pattern if the EnaData is "No". 
 ##        type: string
 ##        required: True
-sequencerPrefix=M0
 #
 # ------------------------------------     PRE-PROCESSING : APPROACH     ------------------------------------
 #
-##     preprocess:
+preprocess=fastp
+##     preprocess --help
 ##        title: preprocess approach
 ##        description: Since the v.2.1.5 of PEMA the user may choose between either the initial PEMA implementation for pre-processing (Trimmomatic, pandaseq) or the latest one (fastp). If you choose the original approach (Trimmomatic) you should skip the fastp-related parameters and vice-versa."""
 ##        type: string
@@ -44,167 +58,187 @@ sequencerPrefix=M0
 ##        validation:
 ##          - value: original
 ##          - value: fastp
-preprocess=fastp
 #
 #   --------------------------     PRE-PROCESSING PARAMETERS : fastp     --------------------------
 #
-##     fastpThreads:
+fastpThreads=3
+##     fastpThreads --help
 ##        title: fastp threads
 ##        description: Number of threads to be used by fastp
 ##        type: integer
 ##        required: False
-fastpThreads=3
+##   --------------------------
 #
-##     disable_adapter_trimming:
+disable_adapter_trimming=True
+##     disable_adapter_trimming --help
 ##        title:
 ##        description: Adapter trimming is enabled by default. If this option is specified, adapter trimming is disabled
 ##        type: boolean
 ##        required: False
-disable_adapter_trimming=True
+##   --------------------------
 #
-##     detect_adapter_for_pe:
+detect_adapter_for_pe=False
+##     detect_adapter_for_pe --help
 ##        title:
 ##        description: Adapter sequence auto-detection.
 ##        type: boolean
 ##        required:
-detect_adapter_for_pe=False
+##   --------------------------
 #
-##     adapter_sequence:
+adapter_sequence="ATCCTC"
+##     adapter_sequence --help
 ##        title:
 ##        description: the adapter for read1.This is used if R1/R2 are found not overlapped.
 ##        type: string
 ##        required: False
 ##        validation:
 ##          -value: {A, T, C, G}*n
-adapter_sequence="ATCCTC"
+##   --------------------------
 #
-##     adapter_sequence_r2:
+adapter_sequence_r2="ATCCTC"
+##     adapter_sequence_r2 --help
 ##        title:
 ##        description: the adapter for read2. This is used if R1/R2 are found not overlapped. If not specified, it will be the same as <adapter_sequence>.
 ##        type: string
 ##        required: False
 ##        validation:
 ##         -value: {A, T, C, G}*n
-adapter_sequence_r2="ATCCTC"
+##   --------------------------
 #
-##     correction:
+correction=True
+##     correction --help
 ##        title: Enable base correction in overlapped regions, default is disabled.
 ##        description:
 ##        type:
 ##        required: False
-correction=True
+##   --------------------------
 #
-##     overrepresentation_analysis:
+overrepresentation_analysis=False
+##     overrepresentation_analysis --help
 ##        title:
 ##        description: enable overrepresented sequence analysis; for a description of the analysis see https://doi.org/10.1093/bioinformatics/bty560  
 ##        type:
 ##        required: False
-overrepresentation_analysis=False
+##   --------------------------
 #
-##     overrepresentation_sampling:
+overrepresentation_sampling=20
+##     overrepresentation_sampling --help
 ##        title:
 ##        description: One in (--overrepresentation_sampling) reads will be computed for overrepresentation analysis (1~10000), smaller is slower, default is 20.
 ##        type: integer
 ##        required: False
-overrepresentation_sampling=20 
+##   --------------------------
 #
-##     overlap_diff_percent_limit
+overlap_diff_percent_limit=20
+##     overlap_diff_percent_limit --help
 ##        title:
 ##        description: The maximum percentage of mismatched bases to detect overlapped region of PE reads. This will affect overlap analysis based PE merge, adapter trimming and correction. Default 20 means 20%.
 ##        type: integer
 ##        required: False
-overlap_diff_percent_limit=20
+##   --------------------------
 #
-##      complexity_threshold:
+complexity_threshold=30
+##      complexity_threshold --help
 ##         title:
 ##         description: The threshold for low complexity filter (0~100). Default is 30, which means 30% complexity is required. 
 ##         type: integer
 ##         required: False
-complexity_threshold=30
+##   --------------------------
 #
-##     length_required:
+length_required=100
+##     length_required --help
 ##        title:
 ##        description: Reads shorter than length_required will be discarded, default is 15.
 ##        type: integer
 ##        required: False
-length_required=100
+##   --------------------------
 #
-##      n_base_limit:
+n_base_limit=5
+##      n_base_limit --help
 ##         title:
 ##         description: If one read's number of N base is >n_base_limit, then this read/pair is discarded. Default is 5.
 ##         type:
 ##         required:
-n_base_limit=5
+##   --------------------------
 #
-##     cut_front:
+cut_front=False
+##     cut_front --help
 ##        title:
 ##        description: Move a sliding window from front (5') to tail, drop the bases in the window if its mean quality < threshold, stop otherwise.
 ##        type:
 ##        required:
-cut_front=False
+##   --------------------------
 #
-##     cut_front_mean_quality:
+cut_front_mean_quality=20
+##     cut_front_mean_quality --help
 ##        title:
 ##        description: The mean quality requirement option for cut_front. Range: 1~36 default: 20 (Q20).
 ##        type: integer
 ##        required: False
-cut_front_mean_quality=20
+##   --------------------------
 #
-##     cut_front_window_size:
+cut_front_window_size=4
+##     cut_front_window_size --help
 ##        title:
 ##        description: The window size option of cut_front. Range: 1~1000, default: 4.
 ##        type: integer
 ##        required: False
-cut_front_window_size=4
+##   --------------------------
 #
-##     cut_tail:
+cut_tail=False
+##     cut_tail --help
 ##        title:
 ##        description: Move a sliding window from tail (3') to front, drop the bases in the window if its mean quality < threshold, stop otherwise.
 ##        type: boolean
 ##        required: False
-cut_tail=False
+##   --------------------------
 #
-##     cut_tail_window_size:
+cut_tail_window_size=4
+##     cut_tail_window_size --help
 ##        title:
 ##        description: The window size option of cut_tail. Range: 1~1000, default: 4.
 ##        type: integer
 ##        required: False
-cut_tail_window_size=4
+##   --------------------------
 #
-##     cut_tail_mean_quality:
+cut_tail_mean_quality=20
+##     cut_tail_mean_quality --help
 ##        title:
 ##        description: The mean quality requirement option for cut_tail. Range: 1~36 default: 20 (Q20)
 ##        type: integer
 ##        required: False
-cut_tail_mean_quality=20
+##   --------------------------
 #
-##     cut_right:
+cut_right=False
+##     cut_right --help
 ##        title:
 ##        description: Move a sliding window from front to tail, if meet one window with mean quality < threshold, drop the bases in the window and the right part, and then stop.
 ##        type: boolean
 ##        required: False
-cut_right=False
+##   --------------------------
 #
-##     cut_right_window_size:
+cut_right_window_size=5
+##     cut_right_window_size --help
 ##        title:
 ##        description: The window size option of cut_right. Range: 1~1000, default: 4.
 ##        type: integer
 ##        required: False
-cut_right_window_size=5
+##   --------------------------
 #
-##     cut_right_mean_quality:
+cut_right_mean_quality=20
+##     cut_right_mean_quality --help
 ##        title:
 ##        description: The mean quality requirement option for cut_right. Range: 1~36 default: 20 (Q20)
 ##        type: integer
 ##        required: False
-cut_right_mean_quality=20
-#
+##   --------------------------
 #
 #   --------------------------     PRE-PROCESSING PARAMETERS : original approach     --------------------------
 #
 #   --------------------------     PRE-PROCESSING PARAMETERS : Trimmomatic     --------------------------
 #
-##     maxInfo:
+maxInfo=Yes
+##     maxInfo --help
 ##        title: maximum information
 ##        description: A Trimmomatic parameter. When enabled, it performs an adaptive quality trim, balancing the benefits of retaining longer reads against the costs of retaining bases with errors.
 ##        type: boolean
@@ -212,9 +246,10 @@ cut_right_mean_quality=20
 ##        validation: 
 ##          - value: Yes
 ##          - value: No
-maxInfo=Yes
+##   --------------------------
 #
-##     targetLength:
+targetLength=100
+##     targetLength --help
 ##        title: maximum information
 ##        description: A Trimmomatic parameter. Specifies the read length which is likely to allow the location of the read within the target sequence to be determined.
 ##        type: integer
@@ -222,9 +257,10 @@ maxInfo=Yes
 ##        validation: 
 ##          - range: 
 ##            min: 1
-targetLength=100
+##   --------------------------
 #
-##     strictness:
+strictness=0.8
+##     strictness --help
 ##        title: strictness
 ##        description: A Trimmomatic parameter. Specifies the balance between preserving as much read length as possible vs. removal of incorrect bases. A low value of this parameter (<0.2) favours longer reads, while a high value (>0.8) favours read correctness.
 ##        type: float
@@ -233,16 +269,18 @@ targetLength=100
 ##          - range:
 ##            min: 0.0
 ##            max: 1.0
-strictness=0.8
+##   --------------------------
 #
-##     adapters:
+adapters=adapters_combined_152_unique.fasta
+##     adapters --help
 ##        title: adapters
 ##        description: A Trimmomatic parameter. Suggested adapter sequences are provided for TruSeq2 (as used in GAII machines) and TruSeq3 (as used by HiSeq and MiSeq machines),
 ##        type: string
 ##        required: True
-adapters=adapters_combined_152_unique.fasta
+##   --------------------------
 #
-##     seedMismatches:
+seedMismatches=0
+##     seedMismatches --help
 ##        title: adapters
 ##        description: A Trimmomatic parameter. Specifies the maximum mismatch count which will still allow a full match to be performed.
 ##        type: integer
@@ -250,9 +288,10 @@ adapters=adapters_combined_152_unique.fasta
 ##        validation: 
 ##          - range: 
 ##            min: 0 
-seedMismatches=0
+##   --------------------------
 #
-##     palindromeClipThreshold:
+palindromeClipThreshold=20
+##     palindromeClipThreshold --help
 ##        title: adapters
 ##        description: A Trimmomatic parameter. Specifies how accurate the match between the two 'adapter ligated' reads must be for PE palindrome read alignment.
 ##        type: integer
@@ -260,9 +299,10 @@ seedMismatches=0
 ##        validation: 
 ##          - range: 
 ##            min: 1 
-palindromeClipThreshold=20
+##   --------------------------
 #
-##     simpleClipThreshold:
+simpleClipThreshold=30
+##     simpleClipThreshold --help
 ##        title: simple ClipThreshold
 ##        description: A Trimmomatic parameter. Specifies how accurate the match between any adapter etc. sequence must be against a read.
 ##        type: integer
@@ -270,9 +310,10 @@ palindromeClipThreshold=20
 ##        validation:
 ##          - range: 
 #-             min: 0 
-simpleClipThreshold=30
+##   --------------------------
 #
-##     leading:
+leading=20
+##     leading --help
 ##        title: simple ClipThreshold
 ##        description: A Trimmomatic parameter. Removes low quality bases from the beginning. As long as a base has a value below this threshold (value of the 'leading' parameter) the base is removed and the next base will be investigated.
 ##        type: integer
@@ -280,9 +321,10 @@ simpleClipThreshold=30
 ##        validation: 
 ##          - range: 
 ##            min: 0 
-leading=20
+##   --------------------------
 #
-##     trailing:
+trailing=2
+##     trailing --help
 ##        title: trailing
 ##        description: A Trimmomatic parameter. Removes low quality bases from the end. As long as a base has a value below this threshold (value of the 'trailing' parameter), the base is removed and the next base (which as Trimmomatic is starting from the 3' prime end, would be base preceding the just removed base) will be investigated.
 ##        type: integer
@@ -290,9 +332,10 @@ leading=20
 ##        validation: 
 ##          - range: 
 ##            min: 0 
-trailing=2
+##   --------------------------
 #
-##     minlen:
+minlen=100
+##     minlen --help
 ##        title: minimum length of the amplicon
 ##        description: A Trimmomatic parameter. Removes reads that fall below the specified minimal length.
 ##        type: integer
@@ -300,9 +343,10 @@ trailing=2
 ##        validation: 
 ##          - range: 
 ##            min: 1
-minlen=100
+##   --------------------------
 #
-##     threadsTrimmomatic:
+threadsTrimmomatic=8
+##     threadsTrimmomatic --help
 ##        title: minimum length of the amplicon
 ##        description: A Trimmomatic parameter. Set how many threads you want Trimmomatic to run into.
 ##        type: integer
@@ -310,12 +354,13 @@ minlen=100
 ##        validation: 
 ##          - range: 
 ##            min: 0 
-threadsTrimmomatic=8
+##   --------------------------
 #
 #
 #   --------------------------     PRE-PROCESSING PARAMETERS : PANDAseq     --------------------------
 #
-##     pandaseqAlgorithm:
+pandaseqAlgorithm=simple_bayesian
+##     pandaseqAlgorithm --help
 ##        title: minimum length of the amplicon
 ##        description: Merging algorithm of the PANDAseq parameter. The user might select among the `simple_bayesian` (Masella 2012), the `pear` (Zhang 2013), the `stich` and the `flash` algorithms.
 ##        type: string
@@ -325,9 +370,10 @@ threadsTrimmomatic=8
 ##          - value: pear 
 ##          - value: stich
 ##          - value: flash
-pandaseqAlgorithm=simple_bayesian
+##   --------------------------
 #
-##     pandaseqThreads:
+pandaseqThreads=8
+##     pandaseqThreads --help
 ##        title: pandaseq threads
 ##        description: Set number of threads to be used from pandaseq. PANDAseq is a I/O bound algorithm. That means that it needs severous time in order to handle the ipnut and output files. while the process is quite fast. However, it does support multithreading and here you can set the number of threads it is going to use.
 ##        type: integer
@@ -335,9 +381,10 @@ pandaseqAlgorithm=simple_bayesian
 ##        validation:
 ##          - range:
 ##            min: 0
-pandaseqThreads=8
+##   --------------------------
 #
-##     pandaseqMinlen:
+pandaseqMinlen=
+##     pandaseqMinlen --help
 ##        title: pandaseq minimum length
 ##        description: Sets the minimum length for a sequence, after primers are removed. By default, all sequences are kept. With this option, sequences shorter than desired can be discarded. In case you need to use this parameter, be sure you leave a tab after 'minlen' and set it like this: '-l 80'. If you do not want to use this parameter, make sure there is nothing after 'minlen'.
 ##        type: integer
@@ -345,9 +392,10 @@ pandaseqThreads=8
 ##        validation: 
 ##          - range: 
 ##            min: 0 
-pandaseqMinlen=
+##   --------------------------
 #
-##     minoverlap:
+minoverlap=1 
+##     minoverlap --help
 ##        title: pandaseq minimum overlap
 ##        description: Sets the minimum overlap between forward and reverse reads. Raising this number does not generally increase the quality of the output as alignments with small overlaps tend to score poorly and are discarded anyway.
 ##        type: integer
@@ -355,9 +403,10 @@ pandaseqMinlen=
 ##        validation:
 ##          - range: 
 ##            min: 0
-minoverlap=1 
+##   --------------------------
 #
-##     threshold:
+threshold=0.6 
+##     threshold --help
 ##        title: threshold
 ##        description: Sets the score, that a sequence must meet to be kept in the output. Any alignments lower than this will be discarded as low quality. Increasing this number will not necessarily prevent uncalled bases (Ns) from appearing in the final sequence. It is also used as the threshold to match primers, if primers are supplied.
 ##        type: float
@@ -366,9 +415,10 @@ minoverlap=1
 ##            - range: 
 ##              min:  0.0
 ##              max: 1.0
-threshold=0.6 
+##   --------------------------
 #
-##     elimination:
+elimination=
+##     elimination --help
 ##        title: elimination
 ##        description: The '-N' parameter eliminates all sequences with uncalled nucleotides in the output. Otherwise, during assembly, uncalled bases (Ns) from unpaired regions may be emitted. If you need -N to be on your analysis, please add '-N' after 'elimination'. Please make sure you leave a tab. If you do not want the parameter to be on, please make sure there is nothing after the 'elimination' parameter.
 ##        type: string
@@ -376,11 +426,12 @@ threshold=0.6
 ##        validation: 
 ##          - value: ''
 ##          - value: -N
-elimination=
+##   --------------------------
 #
 #   --------------------------        CLUSTERING PARAMETERS           --------------------------
 #
-##     clusteringAlgo:
+clusteringAlgo=algo_Swarm
+##     clusteringAlgo --help
 ##        title: clustering algorithm
 ##        description: For OTU clustering PEMA invokes the vsearch algorithm while for ASVs inference the Swarm. Select which way to go.  
 ##        type: string
@@ -388,11 +439,12 @@ elimination=
 ##        validation:
 ##          - value: algo_Swarm
 ##          - value: algo_vsearch
-clusteringAlgo=algo_Swarm
+##   --------------------------
 #
 #   --------------------------     CLUSTERING PARAMETERS : VSEARCH     --------------------------
 #
-##     vsearchThreads:
+vsearchThreads=8
+##     vsearchThreads --help
 ##        title: vsearch threads
 ##        description: Set the number of threads PANDAseq to use.
 ##        type: integer
@@ -400,9 +452,10 @@ clusteringAlgo=algo_Swarm
 ##        validation:
 ##          - range: 
 ##            min: 0
-vsearchThreads=8
+##   --------------------------
 #
-##     vsearchId:
+vsearchId=0.95
+##     vsearchId --help
 ##        title: vsearch threads
 ##        description: Set a score about the clustering step of the VSEARCH algorithm. Do not add a read into a certain cluster if the pairwise identity with its centroid, is lower than the value of the 'vsearchId' parameter. The pairwise identity is defined as the number of (matching columns) / (alignment length - terminal gaps).
 ##        type: float
@@ -411,11 +464,12 @@ vsearchThreads=8
 ##          - range: 
 ##            min: 0.0
 ##            max: 1.0
-vsearchId=0.95
+##   --------------------------
 #
 #   --------------------------     CLUSTERING PARAMETERS : Swarm     --------------------------
 #
-##     d:
+d=3
+##     d --help
 ##        title: d
 ##        description: Maximum number of differences allowed between two amplicons, meaning that two amplicons will be grouped if they hav e integer (or less) differences.
 ##        type: integer
@@ -423,9 +477,10 @@ vsearchId=0.95
 ##        validation:
 ##          - range: 
 ##            min: 0 
-d=3
+##   --------------------------
 #
-##     boundary:
+boundary=
+##     boundary --help
 ##        title: boundary
 ##        description: By default, an ASV with a mass of 3 or more is considered large. Conversely, an ASV is small if it has a mass of less than 3, meaning that it is composed of either one amplicon of abundance 2, or two amplicons of abundance 1. Any positive value greater than 1 can be specified. Using higher boundary values will speed up the second pass, but also reduce the taxonomical resolution of swarm results.
 ##        type: integer
@@ -433,9 +488,10 @@ d=3
 ##        validation:
 ##          - range: 
 ##            min: 0
-boundary=
+##   --------------------------
 #
-##     swarmThreads:
+swarmThreads=3
+##     swarmThreads --help
 ##        title: swarmThreads
 ##        description: The number of threads (CPUs) the Swarm algorithm is allowed to use
 ##        type: integer
@@ -443,11 +499,12 @@ boundary=
 ##        validation:
 ##          - range: 
 ##            min: 1
-swarmThreads=3
+##   --------------------------
 #
 #  -----------------------------     OLIGOTONS        -------------------------------------
 #
-##     removeOligotons:
+removeOligotons=Yes
+##     removeOligotons --help
 ##        title: removeOligotons
 ##        description:  Remove the oligotons (OTUs that appear with an abuncance less that numOligotons) ?
 ##        type: boolean
@@ -455,9 +512,10 @@ swarmThreads=3
 ##        validation:
 ##          - value: Yes
 ##          - value: No
-removeOligotons=Yes
+##   --------------------------
 #
-##     numOligotons:
+numOligotons=5
+##     numOligotons --help
 ##        title: numOligotons
 ##        description:  The minimum number of reads that have been clustered under the same OTUs in order not to skip that OTU
 ##        type: integer
@@ -465,12 +523,13 @@ removeOligotons=Yes
 ##        validation:
 ##          - range: 
 ##            min: 1
-numOligotons=5
+##   --------------------------
 #
 #
 #   --------------------------     CLASSIFIER       --------------------------
 #
-##     classifierAlgo:
+classifierAlgo=CREST
+##     classifierAlgo --help
 ##        title: classifier algorithm
 ##        description:  """Select classifier for the taxonomy assignment step.
 ##                      If you have 16S, 18S, ITS you should choose CREST. If you have COI, 12S you should choose RDPClassifier. 
@@ -480,19 +539,21 @@ numOligotons=5
 ##        validation:
 ##          - value: RDPClassifier
 ##          - value: CREST
-classifierAlgo=CREST
+##   --------------------------
 #
-##     taxonomyFolderName:
+taxonomyFolderName=my_taxon_assign
+##     taxonomyFolderName --help
 ##        title: number of cores for PaPaRa
 ##        description: Name of the output folder CREST returns. In case you run an analysis for a second, make sure you change this parameter otherwise PEMA will fail. Parameter required if gene: ['16S', '18S', 'ITS'].
 ##        type: string
 ##        required: True 
-taxonomyFolderName=my_taxon_assign
+##   --------------------------
 #
 #
 #   --------------------------     GENE-SPECIFIC : 16S/18S     --------------------------
 #
-##     taxonomyAssignmentMethod:
+taxonomyAssignmentMethod=alignment
+##     taxonomyAssignmentMethod --help
 ##        title: vsearch threads
 ##        description: Select between 2 different approaches of taxonomy assignment (alignment & phylogenetic based). Alignment based taxonomy is based on Silva database (versions 128 or 132). a phylogenetic based assignment, by putting 'phylogeny' in this parameter. In the case of phylogeny based taxonomy assignment, a reference tree created by the PEMA group and based on Silva v.128 is used. Parameter required only if gene: gene_16S.
 ##        type: string
@@ -500,9 +561,10 @@ taxonomyFolderName=my_taxon_assign
 ##        validation: 
 ##          - value: alignment
 ##          - value: phylogeny
-taxonomyAssignmentMethod=alignment
+##   --------------------------
 #
-##     numberOfCoresForPapara:
+numberOfCoresForPapara=7
+##     numberOfCoresForPapara --help
 ##        title: number of cores for PaPaRa
 ##        description: In case of phylogeny based taxonomy assignment, set the number of threads the PaPaRa software will use. The parameeter is required if axonomyAssignmentMethod: phylogeny and gene: gene_16S
 ##        type: integer
@@ -510,9 +572,10 @@ taxonomyAssignmentMethod=alignment
 ##        validation:
 ##          - range:
 ##            min: 0
-numberOfCoresForPapara=7
+##   --------------------------
 #
-##     referenceDb:
+referenceDb=midori_1
+##     referenceDb --help
 ##        title: reference database 
 ##        description: When you use the alignment-based taxonomy assignment, then the LCAClassifier from the CREST algorithm, uses a Silva version for the assignment. PEMA allows you to choose between the two last version of Silva. Hence, set the "silvaVersion" parameter either as 'silva_128' or as 'silva_132' depending on the version of your choice. In case you are running 18S rRNA data, you may also use the PR2 database, by setting the referenceDb parametera as 'pr2'. The parameter is required if custom_ref_db: No and gene: [gene_16S, 'gene_18S', 'gene_COI']
 ##        type: string
@@ -523,11 +586,12 @@ numberOfCoresForPapara=7
 ##          - value: pr2
 ##          - value: midori_1
 ##          - value: midori_2
-referenceDb=midori_1
+##   --------------------------
 #
 #   --------------------------     GENE-SPECIFIC : ITS     --------------------------
 #
-##     cutadapt:
+cutadapt=Yes
+##     cutadapt --help
 ##        title: perform a cutadapt script to 
 ##        description: 
 ##        type: string
@@ -535,25 +599,28 @@ referenceDb=midori_1
 ##        validation:
 ##          - value: Yes
 ##          - value: No 
-cutadapt=Yes
+##   --------------------------
 #
-##     forwardITSPrimer:
+forwardITSPrimer=GATGAAGAACGYAGYRAA
+##     forwardITSPrimer --help
 ##        title: forward ITS primer
 ##        description: Provide the forward primer used (only in case of ITS). The parameter is required only in case that gene: gene_ITS.
 ##        type: string
 ##        required: True 
-forwardITSPrimer=GATGAAGAACGYAGYRAA
+##   --------------------------
 #
-##     reverseITSPrimer:
+reverseITSPrimer=CTBTTVCCKCTTCACTCG
+##     reverseITSPrimer --help
 ##        title: reverse ITS primer
 ##        description: Provide the reverse primer used (only in case of ITS). The parameter is required only in case that gene: gene_ITS.
 ##        type: string
 ##        required: True 
-reverseITSPrimer=CTBTTVCCKCTTCACTCG
+##   --------------------------
 #
 #   --------------------------     GENE-SPECIFIC : COI     --------------------------
 #
-##     abskew:
+abskew=2
+##     abskew --help
 ##        title: abskew
 ##        description: PEMA invokes the UCHIME_DENOVO3 algorithm for the chimera removal in the case of the COI marker gene. Probably, for environmental studies a low abskew is better, while in more specific studies a larger one would fit most. The parameter is required only if gene: gene_COI
 ##        type: integer
@@ -561,11 +628,12 @@ reverseITSPrimer=CTBTTVCCKCTTCACTCG
 ##        validation:
 ##          - range:
 ##            min: 0
-abskew=2
+##   --------------------------
 #
 #   --------------------------     CUSTOM REFERENCE DATABASE     --------------------------
 #
-##     custom_ref_db:
+custom_ref_db=No
+##     custom_ref_db --help
 ##        title: custom reference database
 ##        description: Use a custom reference database for the taxonomy assignment step. In this case, extra input files are required depending on the classifier the user selected. To see more on how these files should be in case of the RDPClassifier, follow this link: https://hariszaf.github.io/pema_documentation/training_rdpclassifier/. In case that the CREST classifier is be used, follow this link: https://hariszaf.github.io/pema_documentation/training_crest_classifier/. Remember that as containers are lost when exit from one, you will have to train the classifier, every time you run a new PEMA container If you are about to use a custom ref db, set the following parameter as 'Yes'. Otherwise, it must be set as 'No'. The `name_of_custom_db` may be empty or no depending on whether you will use a custom db or not.
 ##        type: boolean
@@ -573,19 +641,21 @@ abskew=2
 ##        validation:
 ##          - value: Yes
 ##          - value: No
-custom_ref_db=No
+##   --------------------------
 #
-##     name_of_custom_db:
+name_of_custom_db=
+##     name_of_custom_db --help
 ##        title: name of custom database
 ##        description: Name of how custom reference database will be named. Parameter required only if custom_ref_db: Yes
 ##        type: string
 ##        required: True
-name_of_custom_db=
+##   --------------------------
 #
 #
 #   --------------------------     PHYLOSEQ - SPECIFIC     --------------------------
 #
-##     phyloseq:
+phyloseq=No
+##     phyloseq --help
 ##        title: phyloseq
 ##        description: To use Phyloseq set the following  parameter 'phyloseq' with 'Yes'. Please remember that in order to use phyloseq a "metadata.csv" file is necessary to be part of your anaylis folder. 
 ##        type: boolean
@@ -593,9 +663,10 @@ name_of_custom_db=
 ##        validation:
 ##          - value: Yes
 ##          - value: No
-phyloseq=No
+##   --------------------------
 #
-##     tree:
+tree=No
+##     tree --help
 ##        title: tree
 ##        description: The phyloseq object can handle phylogenetic trees as well. PEMA uses RAxML-ng in order to build such trees. Do you want to create such a tree with your OTUs? In case you build this once, you can use it as many times as you want. Parameter required if phyloseq: Yes.
 ##        type: boolean
@@ -603,9 +674,10 @@ phyloseq=No
 ##        validation:
 ##          - value: Yes
 ##          - value: No
-tree=No
+##   --------------------------
 #
-##     raxmlThreads:
+raxmlThreads=5
+##     raxmlThreads --help
 ##        title: raxml threads
 ##        description: Set the number of threads raxml is allowed to use. Paameter required if phyloseq: Yes and tree: Yes.
 ##        type: integer
@@ -613,9 +685,10 @@ tree=No
 ##        validation:
 ##          - range: 
 ##              min: 0  
-raxmlThreads=5
+##   --------------------------
 #
-##     parsTrees:
+parsTrees=5
+##     parsTrees --help
 ##        title: parsimony trees
 ##        description: Number of parsimony trees raxml-ng will go for. Parameter required if phyloseq: Yes and tree: Yes
 ##        type: integer
@@ -623,9 +696,10 @@ raxmlThreads=5
 ##        validation: 
 ##          - range: 
 ##              min: 0 
-parsTrees=5
+##   --------------------------
 #
-##     bootstrapTrees:
+bootstrapTrees=5
+##     bootstrapTrees --help
 ##        title: bootstrap trees
 ##        description: Number of bootstrap trees raxml-ng will go for. Parameter required if phyloseq: Yes and tree: Yes
 ##        type: integer
@@ -633,11 +707,12 @@ parsTrees=5
 ##        validation:
 ##          - range: 
 ##              min: 0 
-bootstrapTrees=5
+##   --------------------------
 #
 #   --------------------------     sum up      --------------------------
 #
-##     emptyRawDataFile:
+emptyRawDataFile=Yes
+##     emptyRawDataFile --help
 ##        title: empty raw data files 
 ##        description: Move raw data to a new folder
 ##        type: boolean
@@ -645,9 +720,10 @@ bootstrapTrees=5
 ##        validation:
 ##          - value: Yes
 ##          - value: No
-emptyRawDataFile=Yes
+##   --------------------------
 #
-##     emptyCheckpoints:
+emptyCheckpoints=Yes
+##     emptyCheckpoints --help
 ##        title: empty check points
 ##        description: Move all check points returned in a separate folder
 ##        type: boolean
@@ -655,9 +731,10 @@ emptyRawDataFile=Yes
 ##        validation: 
 ##          - value: Yes
 ##          - value: No
-emptyCheckpoints=Yes
+##   --------------------------
 #
-##     getNCBITaxId:
+getNCBITaxId=Yes
+##     getNCBITaxId --help
 ##        title: get NCBI Taxonomy Id
 ##        description: Link the OTU/ASV taxonomy assignment to its closest NCBI Taxonomy Id, meaning if there is no NCBI Taxonomy id at the species level, PEMA will search for the one of the genus and so on. 
 ##        type: boolean
@@ -665,7 +742,7 @@ emptyCheckpoints=Yes
 ##        validation: 
 ##          - value: Yes
 ##          - value: No
-getNCBITaxId=Yes
+##   --------------------------
 #
 #   --------------------------     PEMA METADATA     --------------------------
 #

--- a/help_files/PEMA's output files.md
+++ b/help_files/PEMA's output files.md
@@ -1,18 +1,24 @@
 # PEMA's output files
 Each of the next paragraphs stands for a subdirectory in the output folder that PEMA creates after each run.
 
-## 1.quality_control
+## qualityReports
 
-The first folder in the output folder contains the results of FastQC; the quality control results. In this folder, there is a folder for each sample, as well as an .html file and a .zip file which contain all the information included in the folder with the sample’s output. The sequences of each sample, could get either a “pass”, “warn” or “fail” to each of FASTQC’s tests. 
+The first folder in the output folder contains the reports of sample sequence quality of FastQC or fastp. 
+
+### FastQC
+In this folder, there is a folder for each sample, as well as an .html file and a .zip file which contain all the information included in the folder with the sample’s output. The sequences of each sample, could get either a “pass”, “warn” or “fail” to each of FASTQC’s tests. 
+
+### fastp
+In this folder thera are file reports in .json and .html formats for each sample.
 
 ## Pre-processing steps
-In folders *2.trimmomatic_output*, *3.correct_by_BayesHammer*, *4.merged_by_SPAdes* and *5.dereplicate_by_obiuniq* the output of each of tool used for the pre-processing steps are placed. 
+In folders *trimmedSequences*, *mergedSequences* and *dereplicateSamples* the output of each of tool used for the pre-processing steps are placed. When the original approach is selected for the preprocessing an additional folder is created called *adjustedSequences*.
 
-## 6.linearized_files
+## linearizedSequences
 
-The folder called “6.linearized_files” contains sample files (.fasta) only with the sequences that remained after the quality control and the pre-processing steps. These files are used to form a single .fasta (“final_all_samples.fasta”). That is the file PEMA will use from this point onwards for the clustering and taxonomy assignment steps.
+The folder called “linearizedSequences” contains sample files (.fasta) only with the sequences that remained after the quality control and the pre-processing steps. These files are used to form a single .fasta (“final_all_samples.fasta”). That is the file PEMA will use from this point onwards for the clustering and taxonomy assignment steps.
 
-## 7.gene_dependent
+## mainOutput
 
 In this folder, all output from clustering and taxonomy assignment steps is placed. Depending on the marker gene, another folder is created (called "gene_16S" or "gene_COI" correspondingly). 
 

--- a/pema_docker_image/modules/initialize.bds
+++ b/pema_docker_image/modules/initialize.bds
@@ -344,7 +344,7 @@ string{} initializeAnalysis(string{} params) {
 
       globalVars{'qualityControl'}  = 'qualityReports'
       globalVars{'trimmomatic'}     = 'trimmedSequences'
-      globalVars{'bayesHammer'}     = 'adjustedSequnces'
+      globalVars{'bayesHammer'}     = 'adjustedSequences'
       globalVars{'spades'}          = 'mergedSequences'
 
       wait

--- a/pema_docker_image/modules/initialize.bds
+++ b/pema_docker_image/modules/initialize.bds
@@ -24,7 +24,7 @@ string{} readParameterFile(string parameter_file) {
       } else {
          string pname, pvalue
          
-         (pname, pvalue) = line.split('\t')       
+         (pname, pvalue) = line.split('=')
          my_case { pname } = pvalue            # keep 1st elemenet as key (parameter) and the second as its value (parameter's value)
          pname = ''
          pvalue = ''


### PR DESCRIPTION
This PR contains changes of version `v2.1.5` of PEMA regarding the `parameters.tsv`, `initialize.bds`, `README.md` files. 

The main change is the parameters file delimiter which is switched from `\t` to `=`. Hope this doesn't create any other conflicts.
 
Log of changes:
```
fcb21a6 (HEAD -> v.2.1.5, origin/v.2.1.5) replace 2.1.4 with 2.1.5 where applicable
78a6b5b add info of 2.1.5 version
11592f2 typo in folder creation for bayesHammer
68659bf change the line.split for the parameters file to = from \t
4c58ed4 change the output folder names
c134753 change the order of each parameter help info, first is the parameter value pair and then the help info
4c6ac14 change the assign symbol from \t to = to avoid confusion. also replace the #= to ## across the file
```